### PR TITLE
Use a single contract address implementation to allow for contract discovery in TokenLoader

### DIFF
--- a/wagmi-disperse/src/App.tsx
+++ b/wagmi-disperse/src/App.tsx
@@ -620,6 +620,7 @@ function App() {
             chainId={realChainId}
             account={address}
             token={token}
+            contractAddress={verifiedAddress?.address}
           />
           {token.symbol && (
             <p className="mt">


### PR DESCRIPTION
Currently TokenLoader uses a separate implementation of disperse contract discovery on a given chain 

This implementation is inferior to the implementation used in App as it does not allow disperse contract discovery on arbitrary chains not hardcoded in

I’ve changed it so the TokenLoader just takes the contractAddress straight from App in the same way that other components do, and removed any redundant checking.