### PR TITLE
fix: resolve infinite loop in contract verification

### DIFF
--- a/wagmi-disperse/src/hooks/useContractVerification.ts
+++ b/wagmi-disperse/src/hooks/useContractVerification.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useBytecode } from "wagmi";
 import { disperse_createx, disperse_legacy } from "../deploy";
 import type { AddressInfo, VerifiedAddress } from "../types";
@@ -20,11 +20,15 @@ export function useContractVerification(
   const legacyDisperseAddress = disperse_legacy.address as `0x${string}`;
   const createxDisperseAddress = disperse_createx.address as `0x${string}`;
 
-  const potentialAddresses = [
-    { address: legacyDisperseAddress, label: "legacy" },
-    { address: createxDisperseAddress, label: "createx" },
-    { address: customContractAddress, label: "custom" },
-  ].filter((item) => !!item.address) as AddressInfo[];
+  const potentialAddresses = useMemo(
+    () =>
+      [
+        { address: legacyDisperseAddress, label: "legacy" },
+        { address: createxDisperseAddress, label: "createx" },
+        { address: customContractAddress, label: "custom" },
+      ].filter((item) => !!item.address) as AddressInfo[],
+    [legacyDisperseAddress, createxDisperseAddress, customContractAddress],
+  );
 
   const addressToCheck = potentialAddresses[currentCheckIndex]?.address;
 


### PR DESCRIPTION
## Summary
- Fix infinite loop caused by recreating `potentialAddresses` array on every render
- Memoize the array using `useMemo` to maintain referential equality

## Problem
The contract verification hook was stuck in an infinite loop, continuously checking the same contract address and logging debug messages that filled the console.

## Root Cause
The `potentialAddresses` array was being recreated on every render, and since it was included in the dependency array of a `useEffect`, this caused the effect to run continuously.

## Solution
Wrapped the `potentialAddresses` array creation in `useMemo` with proper dependencies to prevent unnecessary recreations.

## Test plan
- [x] Verify contract verification no longer loops infinitely
- [x] Ensure contract detection still works correctly across different chains
- [x] Check that custom contract addresses are properly handled
- [x] Confirm no console spam from repeated debug logs