### PR TITLE
Introduce mainnet RPC fallback for contract verification

### DIFF
--- a/wagmi-disperse/src/wagmi.ts
+++ b/wagmi-disperse/src/wagmi.ts
@@ -1,3 +1,4 @@
+import { fallback } from "viem";
 import * as chains from "viem/chains";
 import type { Chain } from "viem/chains";
 import { http, createConfig } from "wagmi";
@@ -10,6 +11,13 @@ const allChains = Object.values(chains).filter(isValidChain);
 const validChains =
   allChains.length > 0 ? (allChains as unknown as [Chain, ...Chain[]]) : ([chains.mainnet] as [Chain, ...Chain[]]);
 
+const MAINNET_RPCS = [
+  "https://ethereum-rpc.publicnode.com",
+  "https://eth.llamarpc.com",
+  "https://1rpc.io/eth",
+  "https://eth.drpc.org",
+];
+
 export const config = createConfig({
   chains: validChains,
   connectors: [
@@ -18,7 +26,9 @@ export const config = createConfig({
     coinbaseWallet(),
     walletConnect({ projectId: import.meta.env.VITE_WC_PROJECT_ID || "YOUR_PROJECT_ID" }),
   ],
-  transports: Object.fromEntries(validChains.map((chain) => [chain.id, http()])),
+  transports: Object.fromEntries(
+    validChains.map((chain) => [chain.id, chain.id === 1 ? fallback(MAINNET_RPCS.map((url) => http(url))) : http()]),
+  ),
 });
 
 declare module "wagmi" {


### PR DESCRIPTION
## Summary

On Ethereum mainnet the app currently shows the disperse contract as **Not Found** even though both the legacy (`0xD152f549545093347A162Dce210e7293f1452150`) and CreateX (`0xd15fE25eD0Dba12fE05e7029C88b10C25e8880E3`) deployments are live.

Root cause: `wagmi-disperse/src/wagmi.ts` calls `http()` with no URL, so viem falls back to each chain's `rpcUrls.default`. For mainnet that is currently `https://eth.merkle.io`, which responds with **HTTP 1015** (Cloudflare rate-limit) from browser origins. The historical secondary `https://cloudflare-eth.com` returns `-32603 Internal error` on `eth_getCode`. `useBytecode` therefore resolves empty, `isDisperseContract` returns `false`, and `useContractVerification` exhausts both candidate addresses before setting `verifiedAddress = null`.

Verified on-chain state against `https://ethereum-rpc.publicnode.com` — both addresses return the expected runtime bytecode.

## Change

Configure a viem `fallback([...])` transport for chain id `1` only, composed of four public RPCs verified against `eth_getCode` for the legacy address:

- `https://ethereum-rpc.publicnode.com`
- `https://eth.llamarpc.com`
- `https://1rpc.io/eth`
- `https://eth.drpc.org`

All other chains retain the existing `http()` default — minimum surface, no config churn, no env vars, no new dependencies (viem's `fallback` is already available through wagmi).

## Test plan

- [x] `pnpm lint` (biome) clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 122 passed, 2 skipped
- [x] `pnpm build` succeeds, bundle sizes unchanged
- [x] Each fallback RPC manually verified via `curl eth_getCode` against the legacy address
- [ ] Reviewer: load the app on mainnet, confirm contract verifies and ether/token disperse paths are reachable